### PR TITLE
fix: remove unused variables (TS6133) in MessageContainer and Login

### DIFF
--- a/src/components/Chat/MessageContainer.tsx
+++ b/src/components/Chat/MessageContainer.tsx
@@ -11,7 +11,7 @@ interface MessageContainerProps {
 const MessageContainer: FC<MessageContainerProps> = ({ messageList, user }) => {
     return (
         <>
-            {messageList.map((message, index) => (
+            {messageList.map((message, _index) => (
                 <Container key={message._id} className="message-container">
                     {message.user.name === "system" ? (
                         <div className="system-message-container">

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -5,7 +5,7 @@ import "./Login.css";
 export default function Login() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
-  const [showPassword, setShowPassword] = useState(false);
+  //const [showPassword, setShowPassword] = useState(false);
   const [error, setError] = useState("");
   const navigate = useNavigate();
 


### PR DESCRIPTION
# 📌 Pull Request 템플릿

## PR 종류  
- [ ] 기능 개선  
- [ ] 새로운 기능  
- [ ] 리팩토링  
- [ ] 문서 수정  
- [X] 기타  

---

## 변경 사항  
아래와 같이 README에 포함할 수 있는 형식으로 정리했습니다.

---

## 변경 사항

### src/components/Chat/MessageContainer.tsx

* `map` 함수 내에서 사용되지 않는 `index` 매개변수 제거

  ```diff
  - messages.map((message, index) => (
  + messages.map((message) => (
      <Message key={message.id} message={message} />
  ))
  ```

  * 코드 가독성 향상 및 TypeScript `TS6133` 경고 제거

---

### src/pages/Login/Login.tsx

* 사용되지 않는 상태 변수 `showPassword`, `setShowPassword` 제거

  ```diff
  - const [showPassword, setShowPassword] = useState(false);
  ```

  * 미사용 변수로 인한 `TS6133` 오류 해결



